### PR TITLE
Jjorgeb/update eol sso

### DIFF
--- a/eol_survey/tests.py
+++ b/eol_survey/tests.py
@@ -1553,24 +1553,24 @@ class TestEolSurveyReportView(ModuleStoreTestCase):
         response = EolSurveyReportAnalyticsView.have_permission(self, self.user_instructor, '1111111111')
         self.assertFalse(response)
 
-    @patch('eol_survey.utils.get_user_id_doc_id_pairs')
-    def test_get_enrolled_users_with_doc_id(self, mock_user_id_doc_id_pair):
+    @patch('eol_survey.utils.get_user_id_with_indiv_id_list')
+    def test_get_enrolled_users_with_indiv_id(self, mock_user_id_with_indiv_id_list):
         """
-        Test get_all_enrolled_users when the users have a doc_id associated with them.
+        Test get_all_enrolled_users when the users have a indiv_id associated with them.
         """
-        mock_user_id_doc_id_pair.return_value = [(self.student.id, '1234567K'), (self.student2.id, '12345678')]
+        mock_user_id_with_indiv_id_list.return_value = [(self.student.id, '1234567K'), (self.student2.id, '12345678')]
         enrolled_users = get_all_enrolled_users(self.course.id)
-        self.assertEqual(enrolled_users[self.student.username]['doc_id'], '1234567K')
-        self.assertEqual(enrolled_users[self.student2.username]['doc_id'], '12345678')
-        self.assertEqual(enrolled_users[self.data_researcher_user.username]['doc_id'], '')
+        self.assertEqual(enrolled_users[self.student.username]['indiv_id'], '1234567K')
+        self.assertEqual(enrolled_users[self.student2.username]['indiv_id'], '12345678')
+        self.assertEqual(enrolled_users[self.data_researcher_user.username]['indiv_id'], '')
 
-    @patch('eol_survey.utils.get_user_id_doc_id_pairs')
-    def test_get_enrolled_users_without_doc_id(self, mock_user_id_doc_id_pair):
+    @patch('eol_survey.utils.get_user_id_with_indiv_id_list')
+    def test_get_enrolled_users_without_indiv_id(self, mock_user_id_with_indiv_id_list):
         """
-        Test get_all_enrolled_users when the users doesn't have a doc_id associated with them.
+        Test get_all_enrolled_users when the users doesn't have a indiv_id associated with them.
         """
-        mock_user_id_doc_id_pair.return_value = []
+        mock_user_id_with_indiv_id_list.return_value = []
         enrolled_users = get_all_enrolled_users(self.course.id)
-        self.assertEqual(enrolled_users[self.student.username]['doc_id'], '')
-        self.assertEqual(enrolled_users[self.student2.username]['doc_id'], '')
-        self.assertEqual(enrolled_users[self.data_researcher_user.username]['doc_id'], '')
+        self.assertEqual(enrolled_users[self.student.username]['indiv_id'], '')
+        self.assertEqual(enrolled_users[self.student2.username]['indiv_id'], '')
+        self.assertEqual(enrolled_users[self.data_researcher_user.username]['indiv_id'], '')

--- a/eol_survey/utils.py
+++ b/eol_survey/utils.py
@@ -7,7 +7,7 @@ import logging
 from django.contrib.auth.models import User
 from django.http import HttpResponse, JsonResponse
 from django.utils.translation import gettext as _
-from uchileedxlogin.services.interface import get_user_id_doc_id_pairs
+from eol_sso.services.interface import get_user_id_with_indiv_id_list
 import six
 
 # Edx dependencies
@@ -114,7 +114,7 @@ def set_data(response, students, user_states, questions_ids):
     responses = [
             response['username'], 
             students[response['username']]['email'], 
-            students[response['username']]['doc_id'],
+            students[response['username']]['indiv_id'],
             ]
     aux_response = {}
     for user_state in user_states:
@@ -133,11 +133,11 @@ def get_all_enrolled_users(course_key):
         courseenrollment__is_active=1,
     ).order_by('username').values('id', 'username', 'email')
     user_id_list = enrolled_students.values_list('id', flat=True)
-    user_doc_id = get_user_id_doc_id_pairs(user_id_list)
-    user_doc_id_dict = {id: doc_id for id, doc_id in user_doc_id}
+    user_indiv_id = get_user_id_with_indiv_id_list(user_id_list)
+    user_indiv_id_dict = {user_id: indiv_id for user_id, indiv_id in user_indiv_id}
     for user in enrolled_students:
-        doc_id = user_doc_id_dict.get(user['id'], '')
-        students[user['username']] = {'email': user['email'], 'doc_id': doc_id}
+        indiv_id = user_indiv_id_dict.get(user['id'], '')
+        students[user['username']] = {'email': user['email'], 'indiv_id': indiv_id}
     return students
 
 def get_report_xblock(block_key, user_states, block):

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def package_data(pkg, roots):
 
 setuptools.setup(
     name="eol_survey",
-    version="2.0.0",
+    version="3.0.0",
     author="Oficina EOL UChile",
     author_email="eol-ing@uchile.cl",
     description="Eol Survey",

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,1 +1,2 @@
 -e git+https://github.com/eol-uchile/uchileedxlogin@1.0.0#egg=uchileedxlogin
+-e git+https://github.com/eol-uchile/eol_sso@1.0.1#egg=eol_sso


### PR DESCRIPTION
Se actualiza eol_survey para utilizar eol_sso en vez de uchileedxlogin.
Se reemplazan las menciones de doc_id por indiv_id.
Se actualizan los tests y sus requirements.